### PR TITLE
 Install foreman

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+mailcatcher: mailcatcher -f
+rails: bundle exec rails server -p $PORT

--- a/README.md
+++ b/README.md
@@ -31,5 +31,9 @@ To Run and view code:
  Run the server: $ rails s
  
  View the page on localhost:3000 is the normal default
+
+ # Or use Foreman
+  - gem install foreman
+  - $ foreman start
  
  Good to go!


### PR DESCRIPTION
Now that we have multiple processes we need to start (rails s and mailcatcher) it's nice to have a single command to get things going (we'll likely have more processes later).  To start things now
- gem install foreman
- run `foreman start`

The mailcatcher and rails processes will start up and log to the same terminal window.  So far i've seen that the logs are one request behind the actual browser but looks like things are working.
